### PR TITLE
Fixed /etc/default/ovn-central Always Used

### DIFF
--- a/manifests/northd.pp
+++ b/manifests/northd.pp
@@ -51,7 +51,7 @@ class ovn::northd(
                           ' ')
 
   augeas { 'config-ovn-northd':
-    context => $::ovn::params::ovn_northd_context,
+    context => "${::ovn::params::ovn_northd_context}/${package_name}",
     changes => "set ${$::ovn::params::ovn_northd_option_name} '\"${ovn_northd_opts}\"'",
     before  => Service['northd'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class ovn::params {
           $ovn_northd_service_name        = 'ovn-northd'
           $ovn_northd_service_status      = true
           $ovn_northd_service_pattern     = undef
-          $ovn_northd_context             = '/files/etc/sysconfig/ovn-northd'
+          $ovn_northd_context             = '/files/etc/sysconfig'
           $ovn_northd_option_name         = 'OVN_NORTHD_OPTS'
           $ovn_controller_service_name    = 'ovn-controller'
           $ovn_controller_service_status  = true
@@ -19,7 +19,7 @@ class ovn::params {
           $ovn_northd_service_name        = 'ovn-central'
           $ovn_northd_service_status      = false # status broken in UCA
           $ovn_northd_service_pattern     = 'ovn-northd'
-          $ovn_northd_context             = '/files/etc/default/ovn-central'
+          $ovn_northd_context             = '/files/etc/default'
           $ovn_northd_option_name         = 'OVN_CTL_OPTS'
           $ovn_controller_service_name    = 'ovn-host'
           $ovn_controller_service_status  = false # status broken in UCA


### PR DESCRIPTION
# Summary

Changing OVN to be able to use the `/etc/default/<package>` instead of `/etc/default/ovn-central`